### PR TITLE
Now independent also have affinity

### DIFF
--- a/abstract_method.h
+++ b/abstract_method.h
@@ -25,7 +25,6 @@ public:
     int get_num_partitions() const;
     int hash_function(uint64_t key) const;
     void print_hash_values(const vector<tuple<uint64_t, uint64_t>>& data) const;
-    
     bool read_affinity_file();
     
     virtual void work(int thread_index, const vector<tuple<uint64_t, uint64_t>>& data, int start_index, int bucket_size) = 0;


### PR DESCRIPTION
Now the independent method also has affinity 

I have just copied the code from the concurrent method, I know it could be implemented in a better way by using the AbstractMethod class, but i decided it was not worth the time and effort

So now both the concurrent method and independent method have the set affinity method